### PR TITLE
Add lightline.vim support

### DIFF
--- a/autoload/lightline/colorscheme/monokai-pro.vim
+++ b/autoload/lightline/colorscheme/monokai-pro.vim
@@ -24,8 +24,8 @@ let s:p.inactive.middle = [ [ s:fg, s:bg0 ] ]
 let s:p.tabline.left = [ [ s:bg0, s:orange ] ]
 let s:p.tabline.tabsel = [ [ s:bg0, s:yellow ] ]
 let s:p.tabline.middle = copy(s:p.normal.middle)
-let s:p.tabline.right = [ [ s:bg0, s:purple ] ]
+let s:p.tabline.right = [ [ s:bg0, s:magenta ] ]
 let s:p.normal.error = [ [ s:red, s:bg2 ] ]
 let s:p.normal.warning = [ [ s:yellow, s:bg1 ] ]
 
-let g:lightline#colorscheme#monokaipro#palette = lightline#colorscheme#flatten(s:p)
+let g:lightline#colorscheme#monokai-pro#palette = lightline#colorscheme#flatten(s:p)

--- a/autoload/lightline/colorscheme/monokai-pro.vim
+++ b/autoload/lightline/colorscheme/monokai-pro.vim
@@ -1,0 +1,31 @@
+let s:fg = [ '#fdf9f3', 223 ]
+let s:bg0 = [ '#2b292e', 236 ]
+let s:bg1 = [ '#3d3b40', 246 ]
+let s:bg2 = [ '#575558', 245 ]
+let s:red = [ '#FF6188', 167 ]
+let s:orange = [ '#FC9867', 208 ]
+let s:yellow = [ '#FFD866', 214 ]
+let s:green = [ '#A9DC76', 108 ]
+let s:cyan = [ '#78DCE8', 108 ]
+let s:blue = [ '#AB9DF2', 109 ]
+let s:magenta = [ '#DC9DF2', 175 ]
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+
+let s:p.normal.left = [ [ s:bg0, s:green ], [ s:fg, s:bg1 ] ]
+let s:p.normal.right = [ [ s:bg0, s:green ], [ s:fg, s:bg1 ] ]
+let s:p.inactive.right = [ [ s:fg, s:bg1 ], [ s:fg, s:bg2 ] ]
+let s:p.inactive.left =  [ [ s:fg, s:bg1 ], [ s:fg, s:bg2 ] ]
+let s:p.insert.left = [ [ s:bg0, s:magenta ], [ s:fg, s:bg1 ] ]
+let s:p.replace.left = [ [ s:bg0, s:red ], [ s:fg, s:bg1 ] ]
+let s:p.visual.left = [ [ s:bg0, s:orange ], [ s:fg, s:bg1 ] ]
+let s:p.normal.middle = [ [ s:fg, s:bg0 ] ]
+let s:p.inactive.middle = [ [ s:fg, s:bg0 ] ]
+let s:p.tabline.left = [ [ s:bg0, s:orange ] ]
+let s:p.tabline.tabsel = [ [ s:bg0, s:yellow ] ]
+let s:p.tabline.middle = copy(s:p.normal.middle)
+let s:p.tabline.right = [ [ s:bg0, s:purple ] ]
+let s:p.normal.error = [ [ s:red, s:bg2 ] ]
+let s:p.normal.warning = [ [ s:yellow, s:bg1 ] ]
+
+let g:lightline#colorscheme#monokaipro#palette = lightline#colorscheme#flatten(s:p)

--- a/autoload/lightline/colorscheme/monokai-pro.vim
+++ b/autoload/lightline/colorscheme/monokai-pro.vim
@@ -10,22 +10,24 @@ let s:cyan = [ '#78DCE8', 108 ]
 let s:blue = [ '#AB9DF2', 109 ]
 let s:magenta = [ '#DC9DF2', 175 ]
 
-let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+if exists('g:lightline')
+  let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
-let s:p.normal.left = [ [ s:bg0, s:green ], [ s:fg, s:bg1 ] ]
-let s:p.normal.right = [ [ s:bg0, s:green ], [ s:fg, s:bg1 ] ]
-let s:p.inactive.right = [ [ s:fg, s:bg1 ], [ s:fg, s:bg2 ] ]
-let s:p.inactive.left =  [ [ s:fg, s:bg1 ], [ s:fg, s:bg2 ] ]
-let s:p.insert.left = [ [ s:bg0, s:magenta ], [ s:fg, s:bg1 ] ]
-let s:p.replace.left = [ [ s:bg0, s:red ], [ s:fg, s:bg1 ] ]
-let s:p.visual.left = [ [ s:bg0, s:orange ], [ s:fg, s:bg1 ] ]
-let s:p.normal.middle = [ [ s:fg, s:bg0 ] ]
-let s:p.inactive.middle = [ [ s:fg, s:bg0 ] ]
-let s:p.tabline.left = [ [ s:bg0, s:orange ] ]
-let s:p.tabline.tabsel = [ [ s:bg0, s:yellow ] ]
-let s:p.tabline.middle = copy(s:p.normal.middle)
-let s:p.tabline.right = [ [ s:bg0, s:magenta ] ]
-let s:p.normal.error = [ [ s:red, s:bg2 ] ]
-let s:p.normal.warning = [ [ s:yellow, s:bg1 ] ]
+  let s:p.normal.left = [ [ s:bg0, s:green ], [ s:fg, s:bg1 ] ]
+  let s:p.normal.right = [ [ s:bg0, s:green ], [ s:fg, s:bg1 ] ]
+  let s:p.inactive.right = [ [ s:fg, s:bg1 ], [ s:fg, s:bg2 ] ]
+  let s:p.inactive.left =  [ [ s:fg, s:bg1 ], [ s:fg, s:bg2 ] ]
+  let s:p.insert.left = [ [ s:bg0, s:magenta ], [ s:fg, s:bg1 ] ]
+  let s:p.replace.left = [ [ s:bg0, s:red ], [ s:fg, s:bg1 ] ]
+  let s:p.visual.left = [ [ s:bg0, s:orange ], [ s:fg, s:bg1 ] ]
+  let s:p.normal.middle = [ [ s:fg, s:bg0 ] ]
+  let s:p.inactive.middle = [ [ s:fg, s:bg0 ] ]
+  let s:p.tabline.left = [ [ s:bg0, s:orange ] ]
+  let s:p.tabline.tabsel = [ [ s:bg0, s:yellow ] ]
+  let s:p.tabline.middle = copy(s:p.normal.middle)
+  let s:p.tabline.right = [ [ s:bg0, s:magenta ] ]
+  let s:p.normal.error = [ [ s:red, s:bg2 ] ]
+  let s:p.normal.warning = [ [ s:yellow, s:bg1 ] ]
 
-let g:lightline#colorscheme#monokai-pro#palette = lightline#colorscheme#flatten(s:p)
+  let g:lightline#colorscheme#monokaipro#palette = lightline#colorscheme#flatten(s:p)
+endif

--- a/colors/monokai-pro.vim
+++ b/colors/monokai-pro.vim
@@ -1747,20 +1747,5 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   " }}}
 endif
 " }}}
-" Lightline {{{
-let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
-
-let s:p.normal.left     = [ [ s:palette.bg0, s:palette.green ], [ s:palette.fg, s:palette.bg0 ] ]
-let s:p.normal.right    = [ [ s:palette.bg0, s:palette.green ], [ s:palette.fg, s:palette.bg2 ] ]
-let s:p.normal.middle   = [ [ s:palette.blue, s:palette.bg0 ] ]
-let s:p.normal.error    = [ [ s:palette.bg_red, s:palette.red, 'bold' ] ]
-let s:p.normal.warning  = [ [ s:palette.yellow, s:palette.bg0, 'bold' ] ]
-
-let s:p.insert.left     = [ [ s:palette.bg0, s:palette.purple ], [ s:palette.fg, s:palette.bg0 ] ]
-let s:p.replace.left    = [ [ s:palette.bg0, s:palette.blue ], [ s:palette.fg, s:palette.bg0 ] ]
-let s:p.visual.left     = [ [ s:palette.bg0, s:palette.orange ], [ s:palette.fg, s:palette.bg0 ] ]
-
-let g:lightline#colorscheme#monokaipro#palette = lightline#colorscheme#flatten(s:p)
-" }}}
 
 " vim: set sw=2 ts=2 sts=2 et tw=80 ft=vim fdm=marker fmr={{{,}}}:

--- a/colors/monokai-pro.vim
+++ b/colors/monokai-pro.vim
@@ -1747,5 +1747,20 @@ if (has('termguicolors') && &termguicolors) || has('gui_running')
   " }}}
 endif
 " }}}
+" Lightline {{{
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+
+let s:p.normal.left     = [ [ s:palette.bg0, s:palette.green ], [ s:palette.fg, s:palette.bg0 ] ]
+let s:p.normal.right    = [ [ s:palette.bg0, s:palette.green ], [ s:palette.fg, s:palette.bg2 ] ]
+let s:p.normal.middle   = [ [ s:palette.blue, s:palette.bg0 ] ]
+let s:p.normal.error    = [ [ s:palette.bg_red, s:palette.red, 'bold' ] ]
+let s:p.normal.warning  = [ [ s:palette.yellow, s:palette.bg0, 'bold' ] ]
+
+let s:p.insert.left     = [ [ s:palette.bg0, s:palette.purple ], [ s:palette.fg, s:palette.bg0 ] ]
+let s:p.replace.left    = [ [ s:palette.bg0, s:palette.blue ], [ s:palette.fg, s:palette.bg0 ] ]
+let s:p.visual.left     = [ [ s:palette.bg0, s:palette.orange ], [ s:palette.fg, s:palette.bg0 ] ]
+
+let g:lightline#colorscheme#monokaipro#palette = lightline#colorscheme#flatten(s:p)
+" }}}
 
 " vim: set sw=2 ts=2 sts=2 et tw=80 ft=vim fdm=marker fmr={{{,}}}:


### PR DESCRIPTION
I have implemented a setup for the line which I think looks neat. The issue I'm facing is that I cannot get the autoload file to work, so for now (locally) I have tossed its contents in the `colors/monokai-pro.vim` file which is not ideal. If you have any clue as to why don't hesitate to let me know or fix it if you prefer. I'll leave the PR open for changes.

Here are some screenshots:
<img width="945" alt="Screenshot 2020-10-16 at 17 03 52" src="https://user-images.githubusercontent.com/29304787/96275289-d7eac180-0fd1-11eb-8ae4-5279b2d188af.png">
<img width="945" alt="Screenshot 2020-10-16 at 17 03 58" src="https://user-images.githubusercontent.com/29304787/96275295-d9b48500-0fd1-11eb-8edf-1da578182539.png">
<img width="945" alt="Screenshot 2020-10-16 at 17 04 02" src="https://user-images.githubusercontent.com/29304787/96275298-da4d1b80-0fd1-11eb-9e12-2dca5ac4787c.png">
<img width="945" alt="Screenshot 2020-10-16 at 17 04 07" src="https://user-images.githubusercontent.com/29304787/96275301-dae5b200-0fd1-11eb-8401-9029dd88718d.png">
